### PR TITLE
Fixes to wget script template to address issues with TLSv1 and redirects for earlier versions of wget

### DIFF
--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -483,9 +483,7 @@ download_http_sec()
   #Evaluate response.
   #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
   #(( "$redirects" == 1 )) && 
-  if (    ( echo "$http_resp" | grep -q "/esg-orp/" )  \
-       && (( $cmd_exit_status == 6 )) \
-     )      
+  if ( echo "$http_resp" | grep -q "/esg-orp/" )       
   then
    urls=$(echo "$http_resp" | egrep -o 'https://[^ ]+' | cut -d'/' -f 3)
    orp_service=$(echo "$urls" | tr '\n' ' ' | cut -d' ' -f 2)
@@ -539,8 +537,14 @@ decide_openid_service()
    openid_c_tmp="https://""$host""/esgf-idp/openid/" 
   fi
 
-  command="wget "$openid_c_tmp" --no-check-certificate -O-"
-  
+  command="wget "$openid_c_tmp" --no-check-certificate ${force_TLSv1:+--secure-protocol=TLSv1} -O-"
+        
+  if [[ ! -z "$ESGF_WGET_OPT" ]]
+  then
+   command="$command $ESGF_WGET_OPT"
+  fi  
+          
+
   #Execution of command.
   http_resp=$(eval $command  2>&1)
   cmd_exit_status="$?"

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -648,7 +648,7 @@ download_http_sec_open_id()
   if  ((debug))
   then
    echo -e "Executing:\n"
-   echo -e "wget $command\n"
+   echo -e "$command\n"
   fi 
 
   #Execution of command.

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -500,12 +500,11 @@ download_http_sec()
     decide_openid_service
    fi
   else  
-   if      echo "$http_resp" | grep -q "401 Unauthorized"  \
-       ||  echo "$http_resp" | grep -q "403: Forbidden"  \
-       ||  echo "$http_resp" | grep -q "Connection timed out."  \
-       ||  echo "$http_resp" | grep -q "no-check-certificate"  \
-       ||  (( $cmd_exit_status != 0 ))  \
-      
+   if    echo "$http_resp" | grep -q "401 Unauthorized"  \
+      || echo "$http_resp" | grep -q "403: Forbidden"  \
+      || echo "$http_resp" | grep -q "Connection timed out."  \
+      || echo "$http_resp" | grep -q "no-check-certificate"  \
+      || (( $cmd_exit_status != 0 ))      
    then 
     echo "ERROR : http request to OpenID Relying Party service failed."
     failed=1
@@ -551,8 +550,7 @@ decide_openid_service()
 
   if  echo "$http_resp" | grep -q "[application/xrds+xml]"  \
        &&  echo "$http_resp" | grep -q "200 OK"  \
-       && (( cmd_exit_status == 0 ))
-       
+       && (( cmd_exit_status == 0 ))       
   then
    openid_c=$openid_c_tmp
    download_http_sec_open_id
@@ -616,10 +614,9 @@ download_http_sec_cl_id()
    #Evaluate response. 
    #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
    #(( "$redirects" != 5 )) \ 
-   if      echo "$http_resp" | grep -q "text/html"  \
-       ||  echo "$http_resp" | grep -q "403: Forbidden"  \
-       || (( cmd_exit_status != 0 ))
-        
+   if    echo "$http_resp" | grep -q "text/html"  \
+      || echo "$http_resp" | grep -q "403: Forbidden"  \
+      || (( cmd_exit_status != 0 ))        
    then 
     failed=1;
     rm "$filename"  

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -573,10 +573,6 @@ download_http_sec_decide_service()
    if [[ -z "$esgf_uri" ]]
    then
     echo "ERROR : HTTP request to OpenID Relying Party service failed."
-    if ((debug))
-    then
-     echo "Error response: $http_resp"
-    fi
     failed=1
    else
    download_http_sec_cl_id

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -446,7 +446,7 @@ download_http_sec()
    wget_args=" --ca-directory=$WGET_TRUSTED_CERTIFICATES --cookies=on --keep-session-cookies --save-cookies $COOKIES_FOLDER/wcookies.txt "  
   fi 
 
-  if ((use_cookies_for_http_basic_auth_start)) || ((use_cookies_for_http_basic_auth))
+  if ((use_cookies_for_http_basic_auth_start)) || ((use_cookies_for_http_basic_auth)) 
   then
    wget_args=" $wget_args"" --load-cookies $COOKIES_FOLDER/wcookies.txt"    
   fi
@@ -483,7 +483,7 @@ download_http_sec()
   #Evaluate response.
   #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
   #(( "$redirects" == 1 )) && 
-  if ( echo "$http_resp" | grep -q "/esg-orp/" )       
+  if  echo "$http_resp" | grep -q "/esg-orp/"        
   then
    urls=$(echo "$http_resp" | egrep -o 'https://[^ ]+' | cut -d'/' -f 3)
    orp_service=$(echo "$urls" | tr '\n' ' ' | cut -d' ' -f 2)
@@ -500,12 +500,12 @@ download_http_sec()
     decide_openid_service
    fi
   else  
-   if (   ( echo "$http_resp" | grep -q "401 Unauthorized" ) \
-       || ( echo "$http_resp" | grep -q "403: Forbidden" ) \
-       || ( echo "$http_resp" | grep -q "Connection timed out." ) \
-       || ( echo "$http_resp" | grep -q "no-check-certificate" ) \
-       || ( (( $cmd_exit_status != 0 )) ) \
-      )
+   if      echo "$http_resp" | grep -q "401 Unauthorized"  \
+       ||  echo "$http_resp" | grep -q "403: Forbidden"  \
+       ||  echo "$http_resp" | grep -q "Connection timed out."  \
+       ||  echo "$http_resp" | grep -q "no-check-certificate"  \
+       ||  (( $cmd_exit_status != 0 ))  \
+      
    then 
     echo "ERROR : http request to OpenID Relying Party service failed."
     failed=1
@@ -549,10 +549,10 @@ decide_openid_service()
   http_resp=$(eval $command  2>&1)
   cmd_exit_status="$?"
 
-  if (    ( echo "$http_resp" | grep -q "[application/xrds+xml]" ) \
-       && ( echo "$http_resp" | grep -q "200 OK" ) \
+  if  echo "$http_resp" | grep -q "[application/xrds+xml]"  \
+       &&  echo "$http_resp" | grep -q "200 OK"  \
        && (( cmd_exit_status == 0 ))
-      )  
+       
   then
    openid_c=$openid_c_tmp
    download_http_sec_open_id
@@ -593,7 +593,7 @@ download_http_sec_cl_id()
   #Evaluate response.If redirected to idp service send the credentials.
   #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
   #(( redirects == 2  )) && 
-  if ( ( echo "$http_resp" | grep -q "login.htm" ) && (( cmd_exit_status == 0 )) )  
+  if  echo "$http_resp" | grep -q "login.htm"  && (( cmd_exit_status == 0 ))   
   then 
   
    urls=$(echo "$http_resp" | egrep -o 'https://[^ ]+' | cut -d'/' -f 3)
@@ -616,11 +616,10 @@ download_http_sec_cl_id()
    #Evaluate response. 
    #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
    #(( "$redirects" != 5 )) \ 
-   if (   
-          ( echo "$http_resp" | grep -q "text/html" ) \
-       || ( echo "$http_resp" | grep -q "403: Forbidden" ) \
+   if      echo "$http_resp" | grep -q "text/html"  \
+       ||  echo "$http_resp" | grep -q "403: Forbidden"  \
        || (( cmd_exit_status != 0 ))
-      )  
+        
    then 
     failed=1;
     rm "$filename"  
@@ -641,7 +640,7 @@ download_http_sec_cl_id()
 download_http_sec_open_id()
 {
   #Http request for sending openid to the orp web service.
-  command="wget --post-data \"openid_identifier=$openid_c&rememberOpenid=on\" --header=\"esgf-idea-agent-type:basic_auth\" --http-user=\"$username_c\" --http-password=\"$password_c\"    $wget_args ${quiet:+-q} ${quiet:--v} -O $filename https://$orp_service/esg-orp/j_spring_openid_security_check.htm "
+  command="wget --post-data \"openid_identifier=$openid_c&rememberOpenid=on\" --header=\"esgf-idea-agent-type:basic_auth\" --http-user=\"$username_c\" --http-password=\"$password_c\"  $wget_args ${quiet:+-q} ${quiet:--v} -O $filename https://$orp_service/esg-orp/j_spring_openid_security_check.htm "
 
 
 
@@ -659,7 +658,7 @@ download_http_sec_open_id()
   #Evaluate response.
   #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
   #(( "$redirects" != 7 )) ||
-  if ( ( echo "$http_resp" | grep -q "text/html" ) ||  (( $cmd_exit_status != 0 )) )  
+  if   echo "$http_resp" | grep -q "text/html"  ||  (( $cmd_exit_status != 0 ))   
   then
    failed=1;
    rm "$filename"

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -563,9 +563,9 @@ download_http_sec_decide_service()
   fi 
   
 
-  if  echo "$http_resp" | grep -q "[application/xrds+xml]"  \
-       &&  echo "$http_resp" | grep -q "200 OK"  \
-       && (( cmd_exit_status == 0 ))       
+  if    echo "$http_resp" | grep -q "[application/xrds+xml]"  \
+     && echo "$http_resp" | grep -q "200 OK"  \
+     && (( cmd_exit_status == 0 ))       
   then
    openid_c=$openid_c_tmp
    download_http_sec_open_id

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -466,10 +466,10 @@ download_http_sec()
   #use cookies for the next downloads
   use_cookies_for_http_basic_auth=1;
    
-    #Debug message.
+  #Debug message.
   if  ((debug))
   then
-   echo -e "Executing:\n"
+   echo -e "\nExecuting:\n"
    echo -e "wget $wget_args $data\n"
   fi
 
@@ -478,7 +478,12 @@ download_http_sec()
   command="wget $wget_args $data"
   http_resp=$(eval $command  2>&1) 
   cmd_exit_status="$?"
-    
+  
+  if ((debug))
+  then
+   echo "\nHTTP response:\n $http_resp\n"
+  fi
+      
   #Extract orp service from url ?
   #Evaluate response.
   #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
@@ -508,10 +513,6 @@ download_http_sec()
    then 
     echo "ERROR : http request to OpenID Relying Party service failed."
     failed=1
-    if ((debug))
-    then
-     echo "HTTP response: $http_resp"
-    fi
    fi
   fi
 }
@@ -543,10 +544,24 @@ decide_openid_service()
    command="$command $ESGF_WGET_OPTS"
   fi  
           
+  #Debug message.
+  if  ((debug))
+  then
+   echo -e "\nExecuting:\n"
+   echo -e "$command\n"
+  fi
+            
 
   #Execution of command.
   http_resp=$(eval $command  2>&1)
   cmd_exit_status="$?"
+  
+  
+  if ((debug))
+  then
+   echo "\nHTTP response:\n $http_resp\n"
+  fi 
+  
 
   if  echo "$http_resp" | grep -q "[application/xrds+xml]"  \
        &&  echo "$http_resp" | grep -q "200 OK"  \
@@ -581,12 +596,19 @@ download_http_sec_cl_id()
    echo -e "Executing:\n"
    echo -e "wget $command\n"
   fi 
-
-
+  
+  
   #Execution of command.
   http_resp=$(eval $command  2>&1)
   cmd_exit_status="$?"
-   
+
+  
+  if ((debug))
+  then
+   echo "\nHTTP response:\n $http_resp\n"
+  fi 
+    
+  
   #Extract orp service from openid ?
   #Evaluate response.If redirected to idp service send the credentials.
   #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
@@ -596,7 +618,7 @@ download_http_sec_cl_id()
   
    urls=$(echo "$http_resp" | egrep -o 'https://[^ ]+' | cut -d'/' -f 3)
    idp_service=$(echo "$urls"  | tr '\n' ' ' | cut -d' ' -f 2) 
-               
+      
    command="wget --post-data  password=\"$password_c\" $wget_args ${quiet:+-q} ${quiet:--v} -O $filename https://$idp_service/esgf-idp/idp/login.htm"
    
 
@@ -610,7 +632,12 @@ download_http_sec_cl_id()
    #Execution of command.
    http_resp=$(eval $command  2>&1)
    cmd_exit_status="$?"
-   
+      
+   if ((debug))
+   then
+    echo "\nHTTP response:\n $http_resp\n"
+   fi 
+        
    #Evaluate response. 
    #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
    #(( "$redirects" != 5 )) \ 
@@ -624,10 +651,6 @@ download_http_sec_cl_id()
  
   else
    echo "ERROR : HTTP request to OpenID Provider service failed."
-   if ((debug))
-   then
-    echo "Error response: $http_resp"
-   fi
    failed=1
   fi #if redirected to idp.  
 }
@@ -640,7 +663,6 @@ download_http_sec_open_id()
   command="wget --post-data \"openid_identifier=$openid_c&rememberOpenid=on\" --header=\"esgf-idea-agent-type:basic_auth\" --http-user=\"$username_c\" --http-password=\"$password_c\"  $wget_args ${quiet:+-q} ${quiet:--v} -O $filename https://$orp_service/esg-orp/j_spring_openid_security_check.htm "
 
 
-
   #Debug message.
   if  ((debug))
   then
@@ -651,6 +673,12 @@ download_http_sec_open_id()
   #Execution of command.
   http_resp=$(eval $command  2>&1)
   cmd_exit_status="$?"
+  
+  
+  if ((debug))
+  then
+   echo "\nHTTP response:\n $http_resp\n"
+  fi 
 
   #Evaluate response.
   #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
@@ -659,12 +687,28 @@ download_http_sec_open_id()
   then
    failed=1;
    rm "$filename"
+   
+   echo -e "\nRetrying....\n"
+   #Retry in case that last redirect did not work, this happens with older version of wget
+   command="wget $wget_args $data"
+      
+   #Debug message.
+   if  ((debug))
+   then
+    echo -e "Executing:\n"
+    echo -e "$command\n"
+   fi   
+   
+   http_resp=$(eval $command  2>&1) 
+   cmd_exit_status="$?"
+
+      
    if ((debug))
    then
     echo "HTTP response: $http_resp"
    fi
+   
   fi 
-
   
 }
 

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -502,7 +502,7 @@ download_http_sec()
    then
     download_http_sec_open_id
    else
-    decide_openid_service
+    download_http_sec_decide_service
    fi
   else  
    if    echo "$http_resp" | grep -q "401 Unauthorized"  \
@@ -519,7 +519,7 @@ download_http_sec()
 
 
 #Function that decides which implementaion of idp to use.
-decide_openid_service()
+download_http_sec_decide_service()
 {
   #find claimed id
 
@@ -584,6 +584,40 @@ decide_openid_service()
   fi
 }
 
+
+download_http_sec_retry()
+{
+  echo -e "\nRetrying....\n"
+  #Retry in case that last redirect did not work, this happens with older version of wget.
+  command="wget $wget_args $data"
+      
+  #Debug message.
+  if  ((debug))
+  then
+   echo -e "Executing:\n"
+   echo -e "$command\n"
+  fi   
+   
+  http_resp=$(eval $command  2>&1) 
+  cmd_exit_status="$?"
+
+  if ((debug))
+  then
+   echo -e "\nHTTP response:\n $http_resp\n"
+  fi
+   
+  if    echo "$http_resp" | grep -q "401 Unauthorized"  \
+     || echo "$http_resp" | grep -q "403: Forbidden"  \
+     || echo "$http_resp" | grep -q "Connection timed out."  \
+     || echo "$http_resp" | grep -q "no-check-certificate"  \
+     || (( $cmd_exit_status != 0 ))      
+  then 
+   echo -e "\nERROR : Retry failed.\n"
+   rm "$filename"
+   failed=1
+  fi #if retry failed.
+}
+
 #Function for downloading data using the claimed id.
 download_http_sec_cl_id()
 {
@@ -645,8 +679,8 @@ download_http_sec_cl_id()
       || echo "$http_resp" | grep -q "403: Forbidden"  \
       || (( cmd_exit_status != 0 ))        
    then 
-    failed=1;
-    rm "$filename"  
+    rm "$filename"
+    download_http_sec_retry
    fi
  
   else
@@ -686,38 +720,7 @@ download_http_sec_open_id()
   if   echo "$http_resp" | grep -q "text/html"  ||  (( $cmd_exit_status != 0 ))   
   then
    rm "$filename"
-   
-   echo -e "\nRetrying....\n"
-   #Retry in case that last redirect did not work, this happens with older version of wget.
-   command="wget $wget_args $data"
-      
-   #Debug message.
-   if  ((debug))
-   then
-    echo -e "Executing:\n"
-    echo -e "$command\n"
-   fi   
-   
-   http_resp=$(eval $command  2>&1) 
-   cmd_exit_status="$?"
-
-      
-   if ((debug))
-   then
-    echo -e "\nHTTP response:\n $http_resp\n"
-   fi
-   
-   if    echo "$http_resp" | grep -q "401 Unauthorized"  \
-      || echo "$http_resp" | grep -q "403: Forbidden"  \
-      || echo "$http_resp" | grep -q "Connection timed out."  \
-      || echo "$http_resp" | grep -q "no-check-certificate"  \
-      || (( $cmd_exit_status != 0 ))      
-   then 
-    echo -e "\nERROR : Retry failed.\n"
-    rm "$filename"
-    failed=1
-   fi #if retry failed.
-   
+   download_http_sec_retry     
   fi #if error during http basic authentication. 
   
 }

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -481,7 +481,7 @@ download_http_sec()
   
   if ((debug))
   then
-   echo "\nHTTP response:\n $http_resp\n"
+   echo -e "\nHTTP response:\n $http_resp\n"
   fi
       
   #Extract orp service from url ?
@@ -559,7 +559,7 @@ decide_openid_service()
   
   if ((debug))
   then
-   echo "\nHTTP response:\n $http_resp\n"
+   echo -e "\nHTTP response:\n $http_resp\n"
   fi 
   
 
@@ -605,7 +605,7 @@ download_http_sec_cl_id()
   
   if ((debug))
   then
-   echo "\nHTTP response:\n $http_resp\n"
+   echo -e "\nHTTP response:\n $http_resp\n"
   fi 
     
   
@@ -635,7 +635,7 @@ download_http_sec_cl_id()
       
    if ((debug))
    then
-    echo "\nHTTP response:\n $http_resp\n"
+    echo -e "\nHTTP response:\n $http_resp\n"
    fi 
         
    #Evaluate response. 
@@ -677,7 +677,7 @@ download_http_sec_open_id()
   
   if ((debug))
   then
-   echo "\nHTTP response:\n $http_resp\n"
+   echo -e "\nHTTP response:\n $http_resp\n"
   fi 
 
   #Evaluate response.
@@ -685,11 +685,10 @@ download_http_sec_open_id()
   #(( "$redirects" != 7 )) ||
   if   echo "$http_resp" | grep -q "text/html"  ||  (( $cmd_exit_status != 0 ))   
   then
-   failed=1;
    rm "$filename"
    
    echo -e "\nRetrying....\n"
-   #Retry in case that last redirect did not work, this happens with older version of wget
+   #Retry in case that last redirect did not work, this happens with older version of wget.
    command="wget $wget_args $data"
       
    #Debug message.
@@ -705,10 +704,21 @@ download_http_sec_open_id()
       
    if ((debug))
    then
-    echo "HTTP response: $http_resp"
+    echo -e "\nHTTP response:\n $http_resp\n"
    fi
    
-  fi 
+   if    echo "$http_resp" | grep -q "401 Unauthorized"  \
+      || echo "$http_resp" | grep -q "403: Forbidden"  \
+      || echo "$http_resp" | grep -q "Connection timed out."  \
+      || echo "$http_resp" | grep -q "no-check-certificate"  \
+      || (( $cmd_exit_status != 0 ))      
+   then 
+    echo -e "\nERROR : Retry failed.\n"
+    rm "$filename"
+    failed=1
+   fi #if retry failed.
+   
+  fi #if error during http basic authentication. 
   
 }
 

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -130,9 +130,10 @@ debug=0
 clean_work=1
 
 #parse flags
-while getopts ':c:pfF:o:w:isuUndvqhHI:' OPT; do
+while getopts ':c:pfF:o:w:isuUndvqhHI:T' OPT; do
     case $OPT in
         H) skip_security=1 && use_http_sec=1;; #       : Authenticate with OpenID (username,) and password, without the need for a certificate.
+        T) force_TLSv1=1;;              #       : Forces wget to use TLSv1 
         c) ESG_CREDENTIALS="$OPTARG";;  #<cert> : use this certificate for authentication.
         f) force=1;;                    #       : force certificate retrieval (defaults to only once per day); for certificate-less authentication (see -H option), this flag will force login and refresh cookies.
         F) input_file="$OPTARG";;       #<file> : read input from file instead of the embedded one (use - to read from stdin)
@@ -449,6 +450,18 @@ download_http_sec()
   then
    wget_args=" $wget_args"" --load-cookies $COOKIES_FOLDER/wcookies.txt"    
   fi
+  
+  if((force_TLSv1))
+  then
+   wget_args=" $wget_args"" --secure-protocol=TLSv1 "
+  fi
+  
+  
+  if [[ ! -z "$ESGF_WGET_OPT" ]]
+  then
+    wget_args="$wget_args $ESGF_WGET_OPT"
+  fi  
+  
 
   #use cookies for the next downloads
   use_cookies_for_http_basic_auth=1;
@@ -519,7 +532,7 @@ decide_openid_service()
   host=$(echo "$openid_c"  | cut -d'/' -f 3)
   #test ceda first.
 
-  if [ -z "$esgf_uri" ]
+  if [[ -z "$esgf_uri" ]]
   then
    openid_c_tmp="https://""$host""/openid/"
   else
@@ -646,6 +659,10 @@ download_http_sec_open_id()
   then
    failed=1;
    rm "$filename"
+   if ((debug))
+   then
+    echo "HTTP response: $http_resp"
+   fi
   fi 
 
   
@@ -653,7 +670,7 @@ download_http_sec_open_id()
 
 
 download() {
-    wget="wget ${insecure:+--no-check-certificate} ${quiet:+-q} ${quiet:--v} -c $PKI_WGET_OPTS"
+    wget="wget ${insecure:+--no-check-certificate} ${quiet:+-q} ${quiet:--v} -c ${force_TLSv1:+--secure-protocol=TLSv1} $PKI_WGET_OPTS"
     
     while read line
     do

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -133,7 +133,7 @@ clean_work=1
 while getopts ':c:pfF:o:w:isuUndvqhHI:T' OPT; do
     case $OPT in
         H) skip_security=1 && use_http_sec=1;; #       : Authenticate with OpenID (username,) and password, without the need for a certificate.
-        T) force_TLSv1=1;;              #       : Forces wget to use TLSv1 
+        T) force_TLSv1=1;;              #       : Forces wget to use TLSv1. 
         c) ESG_CREDENTIALS="$OPTARG";;  #<cert> : use this certificate for authentication.
         f) force=1;;                    #       : force certificate retrieval (defaults to only once per day); for certificate-less authentication (see -H option), this flag will force login and refresh cookies.
         F) input_file="$OPTARG";;       #<file> : read input from file instead of the embedded one (use - to read from stdin)

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -457,9 +457,9 @@ download_http_sec()
   fi
   
   
-  if [[ ! -z "$ESGF_WGET_OPT" ]]
+  if [[ ! -z "$ESGF_WGET_OPTS" ]]
   then
-    wget_args="$wget_args $ESGF_WGET_OPT"
+    wget_args="$wget_args $ESGF_WGET_OPTS"
   fi  
   
 
@@ -483,7 +483,7 @@ download_http_sec()
   #Evaluate response.
   #redirects=$(echo "$http_resp" | egrep -c ' 302 ')
   #(( "$redirects" == 1 )) && 
-  if  echo "$http_resp" | grep -q "/esg-orp/"        
+  if  echo "$http_resp" | grep -q "/esg-orp/"      
   then
    urls=$(echo "$http_resp" | egrep -o 'https://[^ ]+' | cut -d'/' -f 3)
    orp_service=$(echo "$urls" | tr '\n' ' ' | cut -d' ' -f 2)
@@ -539,9 +539,9 @@ decide_openid_service()
 
   command="wget "$openid_c_tmp" --no-check-certificate ${force_TLSv1:+--secure-protocol=TLSv1} -O-"
         
-  if [[ ! -z "$ESGF_WGET_OPT" ]]
+  if [[ ! -z "$ESGF_WGET_OPTS" ]]
   then
-   command="$command $ESGF_WGET_OPT"
+   command="$command $ESGF_WGET_OPTS"
   fi  
           
 

--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -609,7 +609,7 @@ download_http_sec_retry()
      || (( $cmd_exit_status != 0 ))      
   then 
    echo -e "\nERROR : Retry failed.\n"
-   rm "$filename"
+   #rm "$filename"
    failed=1
   fi #if retry failed.
 }


### PR DESCRIPTION
Updated wget script template:
 * included new `-T` flag to explicitly make it use TLSv1 when communicating with ORP.  This is required for earlier versions of wget ( <= 1.12 ) when communicating with sites which only support TLSv1.
 * Added workaround for wget 1.11.4 as it fails to execute final redirect back to data url following sign in with `-H`.  This fix is compatible with later versions of wget.
 * Added support for additional environment variable `ESGF_WGET_OPTS`.  This can be used in the conjunction with `-H` to globally add additional wget options.  For expert use only!