### PR TITLE
Fix #89

### DIFF
--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -475,7 +475,7 @@ download_http_sec()
 
 
   #Try to download the data. 
-  command="wget $wget_args $data"
+  command="wget $wget_args -O $filename $data"
   http_resp=$(eval $command  2>&1) 
   cmd_exit_status="$?"
   


### PR DESCRIPTION
The command should include the -O option with the file full path. If the -O is not included, after authentication and download succeed with the first file, the forthcoming files are downloaded, using this command, into working directory instead in the output directory. Fix #89