### PR TITLE
Change get_mod_time

### DIFF
--- a/etc/conf/wget-template
+++ b/etc/conf/wget-template
@@ -414,12 +414,12 @@ md5sum_() {
 }
 
 get_mod_time_() {
-    if ((LINUX)); then
-        #on linux modtime is stat -c %Y <file>
-        echo "$(stat -c %Y $@)"
-    elif ((MACOSX)); then
+    if ((MACOSX)); then
         #on a mac modtime is stat -f %m <file>
         echo "$(stat -f %m $@)"
+    else
+        #on linux (cygwin) modtime is stat -c %Y <file>
+        echo "$(stat -c %Y $@)"
     fi
     return 0;
 }


### PR DESCRIPTION
The get_mod_time returns empty if SO is cygwin and therefore no modtime is stored in cache file, making already download files to be downloaded again.