### PR TITLE
Check if the facet list is empty after confirming it is not null

### DIFF
--- a/src/java/main/esg/search/query/impl/solr/SolrUrlBuilder.java
+++ b/src/java/main/esg/search/query/impl/solr/SolrUrlBuilder.java
@@ -279,7 +279,7 @@ public class SolrUrlBuilder {
         if (qs.isEmpty()) qs.add(URLEncoder.encode("*:*", "UTF-8"));      
         
         // &facet.field=...&facet.field=...
-        if (this.facets!=null) {
+        if (this.facets!=null && this.facets.size()!=0) {
             ff.append("&facet=true");
             for (final String facet : this.facets) {
                 ff.append("&facet.field=").append( URLEncoder.encode(facet, UTF8 ));


### PR DESCRIPTION
This code previously resulted in always specifying "facet=true". Now it remains unspecified if no facet fields were provided.

