### PR TITLE
use 'git describe --tags' in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -97,7 +97,7 @@ Builds the project via ant (obviously).
 
   <exec executable="bash" dir="${basedir}" outputproperty="version_num">
     <arg value="-c"/>
-    <arg value="git describe | sed -n 's/v[.]*\([a-zA-Z0-9.]*\)[-]*.*/\1/p'"/>
+    <arg value="git describe --tags"/>
   </exec>
   <exec executable="bash" dir="${basedir}" outputproperty="branch">
     <arg value="-c"/>
@@ -105,7 +105,7 @@ Builds the project via ant (obviously).
   </exec>
   <exec executable="bash" dir="${basedir}" outputproperty="commit">
     <arg value="-c"/>
-    <arg value="git describe"/>
+    <arg value="git describe --tags"/>
   </exec>
   <exec executable="bash" dir="${basedir}" outputproperty="release_name">
     <arg value="-c"/>


### PR DESCRIPTION
If I run the build script on a branch/tag,  I am getting incorrect tag which leads to incorrect version when building the assets.

$ git status
HEAD detached at v4.18.1
nothing to commit, working directory clean
$ git describe --tags
v4.18.1
$ git describe
v4.18.0-2-g8649f77

===
As you can see, 'git describe' returns v4.18.0-**  instead of v4.18.1.

I have tested this change with a new jenkins workflow doing a build and upload (using github api), log is:
https://aims1.llnl.gov/jenkins/job/ESGF_Build/job/esgf-build.esg-search.muryanto1/55/console
