### PR TITLE
Bare-minimum changes to disable publisher authorisation

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ Search API and publishing module for ESGF (see description below)
 Manual esg-search update
 ------------------------
 
-```
+
 # Using > v4.0, service control differs with v2.x, use esg-node stop/start
 # download search module (verify module version
 wget https://github.com/ESGF/esg-search/releases/download/v4.17.10/esg-search.war
@@ -15,7 +15,7 @@ mv /usr/local/tomcat/webapps/esg-search /tmp. # move old version aside
 rm -rf /usr/local/tomcat/work/Catalina/localhost/esg-search # clean out cache
 cp esg-search /usr/local/tomcat/webapps
 /usr/local/tomcat/bin/catalina.sh start # restart tomcat
-```
+
 
 
 Latest version: v4.17.10

--- a/README
+++ b/README
@@ -1,3 +1,23 @@
+esg-search
+==========
+
+Search API and publishing module for ESGF (see description below)
+
+Manual esg-search update
+------------------------
+
+```
+# Using > v4.0, service control differs with v2.x, use esg-node stop/start
+# download search module (verify module version
+wget https://github.com/ESGF/esg-search/releases/download/v4.17.10/esg-search.war
+/usr/local/tomcat/bin/catalina.sh stop # stop tomcat
+mv /usr/local/tomcat/webapps/esg-search /tmp. # move old version aside
+rm -rf /usr/local/tomcat/work/Catalina/localhost/esg-search # clean out cache
+cp esg-search /usr/local/tomcat/webapps
+/usr/local/tomcat/bin/catalina.sh start # restart tomcat
+```
+
+
 Latest version: v4.17.10
 ------------------------
  - Relaxed solr master autocommit to reduce write frequency

--- a/README
+++ b/README
@@ -1,5 +1,11 @@
-DESCRIPTION
+Latest version: v4.17.10
+------------------------
+ - Relaxed solr master autocommit to reduce write frequency
+ - enabled from / to search based on _timestamp
 
+
+DESCRIPTION
+-----------
 
 This module contains the next generation search functionality for the Earth System Grid Federation, 
 built upon the Apache Solr search engine. The package contains functionality for:

--- a/README
+++ b/README
@@ -9,7 +9,7 @@ Manual esg-search update
 
 # Using > v4.0, service control differs with v2.x, use esg-node stop/start
 # download search module (verify module version
-wget https://github.com/ESGF/esg-search/releases/download/v4.17.10/esg-search.war
+wget https://github.com/ESGF/esg-search/releases/download/v4.18.0/esg-search.war
 /usr/local/tomcat/bin/catalina.sh stop # stop tomcat
 mv /usr/local/tomcat/webapps/esg-search /tmp # move old version aside
 rm -rf /usr/local/tomcat/work/Catalina/localhost/esg-search # clean out cache

--- a/README
+++ b/README
@@ -11,9 +11,9 @@ Manual esg-search update
 # download search module (verify module version
 wget https://github.com/ESGF/esg-search/releases/download/v4.17.10/esg-search.war
 /usr/local/tomcat/bin/catalina.sh stop # stop tomcat
-mv /usr/local/tomcat/webapps/esg-search /tmp. # move old version aside
+mv /usr/local/tomcat/webapps/esg-search /tmp # move old version aside
 rm -rf /usr/local/tomcat/work/Catalina/localhost/esg-search # clean out cache
-cp esg-search /usr/local/tomcat/webapps
+cp esg-search.war /usr/local/tomcat/webapps
 /usr/local/tomcat/bin/catalina.sh start # restart tomcat
 
 

--- a/src/java/main/esg/search/config/security-context.xml
+++ b/src/java/main/esg/search/config/security-context.xml
@@ -31,12 +31,5 @@
 	<security:authentication-manager alias="authenticationManager" />
   	<bean id="myUserDetailsService" class="esg.orp.orp.MyUserDetailsService" />
   	
-  	<!-- Authorizer used to secure publishing requests -->
-    <bean name="authorizer" class="esg.orp.app.SAMLAuthorizer">
-        <property name="endpoints">
-                <value>${security.authz.service.endpoint}</value>
-        </property>
-    </bean>
-  	
 
 </beans>

--- a/src/java/main/esg/search/publish/impl/SecurePublishingServiceImpl.java
+++ b/src/java/main/esg/search/publish/impl/SecurePublishingServiceImpl.java
@@ -37,8 +37,6 @@ public class SecurePublishingServiceImpl implements PublishingService {
         this.publishingService = publishingService;
     }
     
-    // NOTE: remove @Autowired to disable access control
-    @Autowired
     public void setAuthorizerAdpater(AuthorizerAdapter authorizer) {
         this.authorizer = authorizer;
     }

--- a/src/java/main/esg/search/publish/impl/SecurePublishingServiceImpl.java
+++ b/src/java/main/esg/search/publish/impl/SecurePublishingServiceImpl.java
@@ -37,6 +37,7 @@ public class SecurePublishingServiceImpl implements PublishingService {
         this.publishingService = publishingService;
     }
     
+    @Autowired(required=false)
     public void setAuthorizerAdpater(AuthorizerAdapter authorizer) {
         this.authorizer = authorizer;
     }

--- a/src/java/main/esg/search/publish/security/AuthorizerAdapter.java
+++ b/src/java/main/esg/search/publish/security/AuthorizerAdapter.java
@@ -32,6 +32,7 @@ public class AuthorizerAdapter {
     
     private final Log LOG = LogFactory.getLog(this.getClass());
     
+    @Autowired(required=false)
     public void setAuthorizer(Authorizer authorizer) {
         this.authorizer = authorizer;
     }

--- a/src/java/main/esg/search/publish/security/AuthorizerAdapter.java
+++ b/src/java/main/esg/search/publish/security/AuthorizerAdapter.java
@@ -32,8 +32,6 @@ public class AuthorizerAdapter {
     
     private final Log LOG = LogFactory.getLog(this.getClass());
     
-    // Note: comment out @Autowired to disable security
-    @Autowired
     public void setAuthorizer(Authorizer authorizer) {
         this.authorizer = authorizer;
     }


### PR DESCRIPTION
Not fully tested (due to the limits of my dev environment), but it seems to work.

Interestingly, I needed to add `<dependency org="javax.ws.rs" name="javax.ws.rs-api" rev="2.0.1"/>` to my ivy.xml to get the publisher API to run. I didn't commit that change, though, since I didn't know how this app is normally deployed.